### PR TITLE
Adds a flexslider patch to override.less

### DIFF
--- a/src/less/overrides.less
+++ b/src/less/overrides.less
@@ -854,3 +854,8 @@ a.logo > img {
 .hid {
 	display:none
 }
+
+.flex-direction-nav a {
+  height: 60px;
+  top: 45%;
+}


### PR DESCRIPTION
Resizing and positioning the boxes of the flexslider navigation arrows, which previously clipped the arrow symbols due to too small height.