### PR TITLE
Fixing compatibility mode issues

### DIFF
--- a/src/theme/template.php
+++ b/src/theme/template.php
@@ -36,12 +36,22 @@ function CLARIN_Horizon_preprocess_html(&$vars) {
       'rel' => 'stylesheet',
       'type' => 'text/css'
     )
-  );  
+  );
+	
+  $compatibilityModeOff = array(
+    '#type' => 'html_tag',
+    '#tag' => 'meta',
+    '#attributes' => array(
+      'http-equiv' => 'X-UA-Compatible',
+      'content' => 'IE=edge'
+    )
+  );
   
   // Add header meta tag for IE to head
   drupal_add_html_head($fontCssLinkSourceSansPro, 'fontCssLinkSourceSansPro');
   drupal_add_html_head($fontCssLinkRobotoSlab, 'fontCssLinkRobotoSlab');
   drupal_add_html_head($fontCssLinkRobotoSlab, 'fontCssLinkSourceCodePro');
+  drupal_add_html_head($compatibilityModeOff, 'compatibilityModeOff');
 }
 
 /**


### PR DESCRIPTION
This changeset is intended to fix https://trac.clarin.eu/ticket/1059, where IE 11 falls into compatibility mode from time to time (rendering like IE 7).
Yet, we do not know what exactly causes IE 11 to issue compatibility mode, but display of a previously saved HTML source code file could be fixed by inserting &lt;meta http-equiv="X-UA-Compatible" content="IE=edge"&gt;
The proposed solution prevents that behavior. 
It will add the meta tag to the HEAD section, overriding the html.tpl.php is not required.