### PR TITLE
fixes advanced search pane display glitch

### DIFF
--- a/src/less/overrides.less
+++ b/src/less/overrides.less
@@ -261,7 +261,7 @@ fieldset legend.panel-heading {
   line-height: 1em;
   margin: 0;
 }
-fieldset .panel-body {
+fieldset .panel-body:not(.collapse) {
   clear: both;
   display: inherit;
 }


### PR DESCRIPTION
Constraining rule
"fieldset .panel-body" not to apply to collapsible items by using 
"fieldset .panel-body:(.collapse)".
Problematic is the display:inherit, which should be display:none for collapsible items (toggles to display:block). Removing the display property is a bad choice either, as there might be flex items somewhere else on the page.